### PR TITLE
Update verification-metadata.xml

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -5,6 +5,10 @@
       <verify-signatures>false</verify-signatures>
       <trusted-artifacts>
          <trust group="net.runelite"/>
+         <trust group="net.runelite.gluegen"/>
+         <trust group="net.runelite.jocl"/>
+         <trust group="net.runelite.jogl"/>
+         <trust group="net.runelite.pushingpixels"/>
       </trusted-artifacts>
    </configuration>
    <components>


### PR DESCRIPTION
You need this for the plugin to build after 1.7.0. It may be possible that simply deleting the file would work as well if you're not actually using any external dependencies.

Whenever you PR this, open a PR on the hub to link the plugin back to your repo.